### PR TITLE
Migrate Travis build to Github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main # Triggers the workflow when commit pushed to master branch
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  release:
+    run-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERUSER }}
+        password: ${{ secrets.DOCKERPASS }}
+    - name: Build and Publish Image
+      run: |
+        DOCKER_CONTENT_TRUST=1 docker build --pull -t "bsycorp/log-forwarder:1.1.${{github.run_number}}" -t "bsycorp/log-forwarder:latest" .
+        docker push bsycorp/log-forwarder:1.1.${{github.run_number}}
+        docker push bsycorp/log-forwarder:latest


### PR DESCRIPTION
Migrate from travis build to Github actions.
Also bump up image version tag from 1.0.x to 1.1.x, and use Github action build number as minor version.